### PR TITLE
Update recovery.fstab

### DIFF
--- a/recovery.fstab
+++ b/recovery.fstab
@@ -5,4 +5,4 @@
 /cache		ext4	/dev/block/platform/msm_sdcc.1/by-name/cache
 /data		ext4	/dev/block/platform/msm_sdcc.1/by-name/userdata	 length=-16384
 /sdcard		datamedia	/dev/null
-/external_sd		auto	/dev/block/mmcblk1p1	/dev/block/mmcblk1
+/external_sd    vfat	/dev/block/mmcblk1p1  /dev/block/mmcblk1 fstype2=auto


### PR DESCRIPTION
you should use this way, or at least with fstype2=ext4 to be able to track vfat partitions in recovery
This is needed by some code parts (allow partition, in work exfat/ntfs mount...)
